### PR TITLE
Tool calls support improvements

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -407,6 +407,10 @@ std::string llama_detokenize(
 struct llama_chat_msg {
     std::string role;
     std::string content;
+    std::string tool_calls;
+
+    llama_chat_msg(std::string role, std::string content, std::string tool_calls = "")
+        : role(role), content(content), tool_calls(tool_calls) {}
 };
 
 // Check if the template supplied via "--chat-template" is supported or not. Returns true if it's valid


### PR DESCRIPTION
Tool calls support improvements

- Handle previous messages that contains tool calls and add them to the context (previously they were considered as empty messages);
- Accept messages that have no content but only tool calls;
- Minor improvements in prompt template for tool calls for Hermes 3.

I have tested the new version using a toy example, but I did not run or modified the tests included in the repository.

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [X] Low
  - [ ] Medium
  - [ ] High
