### PR TITLE
llama : add stdexcept header for std::runtime_error

### DIFF
--- a/src/llama-arch.cpp
+++ b/src/llama-arch.cpp
@@ -4,6 +4,7 @@
 
 #include <map>
 #include <exception>
+#include <stdexcept>
 
 static const std::map<llm_arch, const char *> LLM_ARCH_NAMES = {
     { LLM_ARCH_LLAMA,            "llama"            },


### PR DESCRIPTION
This commit adds the stdexcept header to llama-arch.cpp to allow the use of std::runtime_error.
Currently the following compilation is generated:

```console
/work/ai/new-vision-api/src/llama-arch.cpp: In member function‘std::string BASE_TN_IMPL<Tname, Ttensor>::str() const [with Tname = llm_arch; Ttensor = llm_tensor; std::string = std::__cxx11::basic_string<char>]’:
/home/danbev/work/ai/new-vision-api/src/llama-arch.cpp:1544:20: error: ‘runtime_error’ is not a member of ‘std’
 1544 |         throw std::runtime_error(format("Cannot find tensor name mapping for arch %d", arch));
      |                    ^~~~~~~~~~~~~
```

